### PR TITLE
Pass environment to git clone

### DIFF
--- a/beokay.py
+++ b/beokay.py
@@ -68,7 +68,8 @@ def ensure_paths(parsed_args):
 
 
 def git_clone(repo, branch, path):
-    subprocess.check_call(["git", "clone", repo, path, "--branch", branch])
+    subprocess.check_call(["git", "clone", repo, path, "--branch", branch],
+                          env=os.environ)
 
 
 def clone_kayobe_config(parsed_args):


### PR DESCRIPTION
This allows you to use agent forwarding when cloning using the SSH protocol